### PR TITLE
Update size of validation_data_hsc.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -150,7 +150,7 @@ Example Datasets
         - Takes several hours when running on only a few cores.
         - Not CI-sized under our current Jenkins/AWS node sizes, but would be CI sized large machine.
     b. https://github.com/lsst/validation_data_hsc
-        - 51 GB.
+        - 366 GB.
         - Calibration data available as pre-computed masters and used to do ISR.
         - Currently processed on a daily (8 hour?) cadence through to coadd.
         - Currently not used for DIA.

--- a/index.rst
+++ b/index.rst
@@ -150,7 +150,8 @@ Example Datasets
         - Takes several hours when running on only a few cores.
         - Not CI-sized under our current Jenkins/AWS node sizes, but would be CI sized large machine.
     b. https://github.com/lsst/validation_data_hsc
-        - 366 GB.
+        - 56 GB raw + master calibrations.
+        - The entire `validation_data_hsc` repo is 250 GB because it includes a set of processCcd+coadd processed data.
         - Calibration data available as pre-computed masters and used to do ISR.
         - Currently processed on a daily (8 hour?) cadence through to coadd.
         - Currently not used for DIA.


### PR DESCRIPTION
@parejkoj reports: "`du -sh validation_data_hsc/` on my desktop reports 366 GB, of which 42GB for `CALIB/`, and 16GB for `raw/`. The remainder is in `.git/lfs/`. This is prior to @wmwv’s updates of the processed data."